### PR TITLE
Dependencies to include Python 3.10.* and 3.11.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ keywords = ["django", "djangorestframework", "async"]
 
 
 [tool.poetry.dependencies]
-python = ">=3.8,<=3.10"
+python = ">=3.8,<3.12"
 djangorestframework = ">=3.13.0"
 django = ">=4.1.0"
 


### PR DESCRIPTION
Updating dependencies to include all minor and patch versions of Python 3.10 and 3.11 (released a few days ago).